### PR TITLE
Issues/22 dihedral convention

### DIFF
--- a/magres/atoms.py
+++ b/magres/atoms.py
@@ -234,7 +234,7 @@ class MagresAtomsView(object):
     norm2 = cross(dr23, dr34)
 
     # Get m, where m, norm1 and bond2 form an orthogonal frame
-    m = cross(norm1, dr23)
+    m = cross(dr23, norm1)
 
     # x = cos(theta) where theta is the angle between norm1 and norm2
     x = dot(norm1, norm2)

--- a/unit_tests/test_angles.py
+++ b/unit_tests/test_angles.py
@@ -45,6 +45,11 @@ class MagresDihedral(unittest.TestCase):
   def test_dihedral4(self):
     atoms = MagresAtoms.load_magres(os.path.join(DATA_DIR, "angles/dihedral4.magres"))
   
+    self.assertTrue(allclose(atoms.dihedral(atoms.C1, atoms.C2, atoms.C3, atoms.C4, degrees=True), -45.0))
+
+  def test_dihedral5(self):
+    atoms = MagresAtoms.load_magres(os.path.join(DATA_DIR, "angles/dihedral5.magres"))
+
     self.assertTrue(allclose(atoms.dihedral(atoms.C1, atoms.C2, atoms.C3, atoms.C4, degrees=True), 45.0))
 
 if __name__ == "__main__":

--- a/unit_tests/test_data/angles/dihedral5.magres
+++ b/unit_tests/test_data/angles/dihedral5.magres
@@ -1,0 +1,11 @@
+#$magres-abinitio-v1.0
+<atoms>
+units lattice Angstrom
+lattice 10.0 0.0 0.0 0.0 10.0 0.0 0.0 0.0 10.0   
+units atom Angstrom
+atom C C 1 -1.0 1.0 0.0
+atom C C 2 0.0 0.0 0.0
+atom C C 3 1.0 0.0 0.0
+atom C C 4 2.0 1.0 1.0
+</atoms>
+


### PR DESCRIPTION
Inversion of the sign of the dihedral angle arose from the direction of vector m.  This has been interted by changing m = cross(norm1, dr23) to m = cross(dr23, norm1).

A new test has been added (dihedral5, with associated .magres file) to confirm dihedral4 (-45 degrees) and dihedral5 (+45 degrees) have opposite sign.